### PR TITLE
Adicionar utilitário para detetar arquivos compactados

### DIFF
--- a/src/core/extractor.py
+++ b/src/core/extractor.py
@@ -2,6 +2,24 @@ from pathlib import Path
 from typing import Iterable, Iterator, Tuple
 import io, zipfile, tarfile
 
+
+def is_archive(path: Path, tipos: Iterable[str] | None = None) -> bool:
+    """Verifica se ``path`` aponta para um arquivo suportado."""
+    nome = path.name.lower()
+    suportadas = {
+        "zip",
+        "rar",
+        "7z",
+        "tar",
+        "tgz",
+        "tar.gz",
+        "tbz2",
+        "tar.bz2",
+    }
+    if tipos:
+        suportadas |= {t.lower().lstrip(".") for t in tipos}
+    return any(nome.endswith(f".{ext}") for ext in suportadas)
+
 def iterate_archive(path: Path, extensions: Iterable[str]) -> Iterator[Tuple[str, io.BufferedReader]]:
     """Gera (nome_relativo, stream) para cada ficheiro interno pretendido."""
     want = {e.lower().lstrip(".") for e in extensions}


### PR DESCRIPTION
## Sumário
- acrescenta função `is_archive` para reconhecer ficheiros de arquivo suportados
- garante que os tipos de arquivo fornecidos sejam considerados

## Testes
- `pytest`
- `python -m py_compile src/core/extractor.py src/core/copier.py`


------
https://chatgpt.com/codex/tasks/task_e_68b03261ab4c8325aec731eaf823c7a6