### PR TITLE
Expandir grupos marcados ao mostrar janela

### DIFF
--- a/src/gui_app.py
+++ b/src/gui_app.py
@@ -71,6 +71,11 @@ class MainWindow(QMainWindow):
         self._build_ui()
         self._restore_session()
 
+    # ---------- eventos Qt ----------
+    def showEvent(self, event):
+        super().showEvent(event)
+        self._update_tree_expansion()
+
     # ---------- construção UI ----------
     def _build_ui(self):
         central = QWidget(self)


### PR DESCRIPTION
## Resumo
- garantir que a MainWindow expande grupos com filhos assinalados ao ser mostrada

## Testes
- `pytest -q`
- script manual com Qt para verificar expansão automática de "Imagens"


------
https://chatgpt.com/codex/tasks/task_e_68b03d68154c8325870d79c0e8a1fa1b