### PR TITLE
Guardar destino e escrever log

### DIFF
--- a/src/gui_app.py
+++ b/src/gui_app.py
@@ -67,6 +67,7 @@ class MainWindow(QMainWindow):
 
         self._thread: QThread | None = None
         self._worker: Worker | None = None
+        self.dst: str | None = None
 
         self._build_ui()
         self._restore_session()
@@ -261,6 +262,8 @@ class MainWindow(QMainWindow):
             use_vss=self.chk_vss.isChecked(),
         )
 
+        self.dst = cfg["dst"]
+
         self._save_session(cfg)
         self.progress.setValue(0)
         self.log.clear()
@@ -292,6 +295,13 @@ class MainWindow(QMainWindow):
 
     def _append_log(self, line: str):
         self.log.append(line)
+        if self.dst:
+            try:
+                log_file = Path(self.dst) / "backup_log.txt"
+                with open(log_file, 'a', encoding='utf-8') as fh:
+                    fh.write(line + "\n")
+            except Exception:
+                pass
 
     def _on_finished(self, stats: dict):
         # mostrar resumo


### PR DESCRIPTION
## Resumo
- Guardar o directório de destino na janela principal ao iniciar o backup.
- Registar cada mensagem de log também em `backup_log.txt` no directório de destino.

## Testes
- `python -m py_compile src/gui_app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b040d360e08325ad72cfc03ccb9ad3