### PR TITLE
Gerar relatório PDF do backup

### DIFF
--- a/src/pdf_report.py
+++ b/src/pdf_report.py
@@ -1,0 +1,56 @@
+# src/pdf_report.py
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+from datetime import datetime
+
+from reportlab.lib.pagesizes import A4
+from reportlab.pdfgen import canvas
+
+
+def gerar_relatorio_pdf(stats: Dict, destino: str | Path) -> Path:
+    """Gera um relatório PDF com as estatísticas do backup.
+
+    O ficheiro é guardado com o nome ``backup_relatorio_<data>_<hora>.pdf``.
+
+    Parameters
+    ----------
+    stats: Dict
+        Dicionário com as estatísticas do backup.
+    destino: str | Path
+        Pasta onde o relatório será guardado.
+
+    Returns
+    -------
+    Path
+        Caminho para o ficheiro PDF criado.
+    """
+    destino = Path(destino)
+    destino.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    pdf_path = destino / f"backup_relatorio_{timestamp}.pdf"
+
+    c = canvas.Canvas(str(pdf_path), pagesize=A4)
+    width, height = A4
+    y = height - 50
+
+    c.setFont("Helvetica-Bold", 16)
+    c.drawString(50, y, "Relatório de Backup")
+    y -= 40
+
+    c.setFont("Helvetica", 12)
+    linhas = [
+        f"Ficheiros analisados : {stats.get('files_scanned', 0)}",
+        f"Ficheiros encontrados: {stats.get('files_found', 0)}",
+        f"Ficheiros copiados   : {stats.get('files_copied', 0)}",
+        f"Sem acesso           : {stats.get('files_denied', 0)}",
+        f"MB analisados        : {stats.get('mb_scanned', 0.0):.2f}",
+        f"MB copiados          : {stats.get('mb_copied', 0.0):.2f}",
+    ]
+    for linha in linhas:
+        c.drawString(50, y, linha)
+        y -= 20
+
+    c.save()
+    return pdf_path


### PR DESCRIPTION
## Resumo
- criar utilitário `gerar_relatorio_pdf` com ReportLab
- permitir gerar relatório PDF a partir da aplicação gráfica e abrir a pasta de destino
- incluir data e hora no nome do ficheiro do relatório

## Testes
- `python -m py_compile src/pdf_report.py src/gui_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b046f6b7fc8325b41bb2f3b1482d22