### PR TITLE
Registo de tempos e relatório PDF automático

### DIFF
--- a/src/core/copier.py
+++ b/src/core/copier.py
@@ -79,6 +79,8 @@ def copy_selected(
         files_denied=0,
         mb_scanned=0.0,
         mb_copied=0.0,
+        ext_counts={},
+        ext_sizes={},
     )
 
     if stop_flag is None:
@@ -121,10 +123,14 @@ def copy_selected(
                 _ensure_dir(dst_path)
                 shutil.copy2(path, dst_path)
                 stats["files_copied"] += 1
+                copied_mb = 0.0
                 try:
-                    stats["mb_copied"] += (dst_path.stat().st_size or 0) / (1024 * 1024)
+                    copied_mb = (dst_path.stat().st_size or 0) / (1024 * 1024)
+                    stats["mb_copied"] += copied_mb
                 except Exception:
                     pass
+                stats["ext_counts"][ext_folder] = stats["ext_counts"].get(ext_folder, 0) + 1
+                stats["ext_sizes"][ext_folder] = stats["ext_sizes"].get(ext_folder, 0.0) + copied_mb
                 _emit(log_cb, f"✔ Copiado: {path} -> {dst_path}")
             except PermissionError as e:
                 stats["files_denied"] += 1
@@ -163,10 +169,14 @@ def copy_selected(
                         with open(dst_path, "wb") as fh:
                             shutil.copyfileobj(stream, fh)
                         stats["files_copied"] += 1
+                        copied_mb = 0.0
                         try:
-                            stats["mb_copied"] += (dst_path.stat().st_size or 0) / (1024 * 1024)
+                            copied_mb = (dst_path.stat().st_size or 0) / (1024 * 1024)
+                            stats["mb_copied"] += copied_mb
                         except Exception:
                             pass
+                        stats["ext_counts"][inner_ext] = stats["ext_counts"].get(inner_ext, 0) + 1
+                        stats["ext_sizes"][inner_ext] = stats["ext_sizes"].get(inner_ext, 0.0) + copied_mb
                         _emit(log_cb, f"✔ Extraído: {path}!{inner_name} -> {dst_path}")
                         _progress(progress_cb, 1)
                 except Exception as e:

--- a/src/pdf_report.py
+++ b/src/pdf_report.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Dict
-
 import datetime
-=======
-
 
 from reportlab.lib.pagesizes import A4
 from reportlab.pdfgen import canvas
@@ -15,29 +12,13 @@ from reportlab.pdfgen import canvas
 def gerar_relatorio_pdf(stats: Dict, destino: str | Path) -> Path:
     """Gera um relatório PDF com as estatísticas do backup.
 
-
     O ficheiro é guardado com o nome ``backup_relatorio_<data>_<hora>.pdf``.
-=======
-
-    Parameters
-    ----------
-    stats: Dict
-        Dicionário com as estatísticas do backup.
-    destino: str | Path
-        Pasta onde o relatório será guardado.
-
-    Returns
-    -------
-    Path
-        Caminho para o ficheiro PDF criado.
     """
     destino = Path(destino)
     destino.mkdir(parents=True, exist_ok=True)
 
     timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     pdf_path = destino / f"backup_relatorio_{timestamp}.pdf"
-=======
-
 
     c = canvas.Canvas(str(pdf_path), pagesize=A4)
     width, height = A4
@@ -48,17 +29,57 @@ def gerar_relatorio_pdf(stats: Dict, destino: str | Path) -> Path:
     y -= 40
 
     c.setFont("Helvetica", 12)
+
+    # Tempos
+    inicio = stats.get("start_time")
+    fim = stats.get("end_time")
+    dur = stats.get("duration", 0)
+    if inicio:
+        try:
+            inicio = datetime.datetime.fromisoformat(inicio).strftime("%Y-%m-%d %H:%M:%S")
+        except Exception:
+            pass
+    if fim:
+        try:
+            fim = datetime.datetime.fromisoformat(fim).strftime("%Y-%m-%d %H:%M:%S")
+        except Exception:
+            pass
+
     linhas = [
-        f"Ficheiros analisados : {stats.get('files_scanned', 0)}",
+        f"Início              : {inicio}",
+        f"Fim                 : {fim}",
+        f"Duração (s)         : {dur:.2f}",
+        f"Ficheiros analisados: {stats.get('files_scanned', 0)}",
         f"Ficheiros encontrados: {stats.get('files_found', 0)}",
-        f"Ficheiros copiados   : {stats.get('files_copied', 0)}",
-        f"Sem acesso           : {stats.get('files_denied', 0)}",
-        f"MB analisados        : {stats.get('mb_scanned', 0.0):.2f}",
-        f"MB copiados          : {stats.get('mb_copied', 0.0):.2f}",
+        f"Ficheiros copiados  : {stats.get('files_copied', 0)}",
+        f"Sem acesso          : {stats.get('files_denied', 0)}",
+        f"MB analisados       : {stats.get('mb_scanned', 0.0):.2f}",
+        f"MB copiados         : {stats.get('mb_copied', 0.0):.2f}",
     ]
     for linha in linhas:
-        c.drawString(50, y, linha)
+        if linha is not None:
+            c.drawString(50, y, linha)
+            y -= 20
+
+    # Tipos de ficheiro
+    ext_counts = stats.get("ext_counts", {})
+    ext_sizes = stats.get("ext_sizes", {})
+    if ext_counts:
+        y -= 10
+        c.setFont("Helvetica-Bold", 12)
+        c.drawString(50, y, "Tipos de ficheiro:")
         y -= 20
+        c.setFont("Helvetica", 12)
+        for ext in sorted(ext_counts):
+            count = ext_counts[ext]
+            size = ext_sizes.get(ext, 0.0)
+            c.drawString(60, y, f".{ext}: {count} ficheiros ({size:.2f} MB)")
+            y -= 20
+            if y < 50:
+                c.showPage()
+                y = height - 50
+                c.setFont("Helvetica", 12)
 
     c.save()
     return pdf_path
+


### PR DESCRIPTION
## Sumário
- registo de hora inicial, final e duração total no log
- criação automática do PDF após o backup
- relatório inclui tempos e estatísticas por tipo de ficheiro

## Testes
- `python -m py_compile src/gui_app.py src/core/copier.py src/pdf_report.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0d44b500c8325a6229731af1cf165