### PR TITLE
Adicionar testes unitários e melhorar README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,30 @@
 # backup_app
 
 Aplicação de backup seletivo por tipo de ficheiros com interface gráfica (PySide6).
+
+## Requisitos
+
+- Python 3.10 ou superior
+- Dependências listadas em `requirements.txt`
+
+Instalação das dependências:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Utilização
+
+Para iniciar a aplicação gráfica:
+
+```bash
+python main.py
+```
+
+## Testes
+
+Para correr os testes unitários das funções principais:
+
+```bash
+python -m pytest
+```

--- a/tests/test_copier.py
+++ b/tests/test_copier.py
@@ -1,0 +1,29 @@
+from src.core.copier import copy_selected
+
+
+def test_copy_selected_copies_only_requested(tmp_path):
+    src = tmp_path / 'src'
+    dst = tmp_path / 'dst'
+    src.mkdir()
+    (src / 'doc.txt').write_text('x')
+    sub = src / 'sub'
+    sub.mkdir()
+    (sub / 'foto.jpg').write_text('img')
+
+    progress = []
+    stats = {}
+    copy_selected(
+        src=src,
+        dst=dst,
+        extensions={'jpg'},
+        recursive=True,
+        preserve_structure=True,
+        progress_cb=progress.append,
+        stats=stats,
+    )
+
+    copied = dst / 'jpg' / 'sub' / 'foto.jpg'
+    assert copied.exists()
+    assert not (dst / 'txt').exists()
+    assert stats['files_copied'] == 1
+    assert progress[-1] == 1

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import zipfile
+
+from src.core.extractor import is_archive, iterate_archive
+
+
+def test_is_archive_detects_zip():
+    assert is_archive(Path('ficheiro.zip'))
+    assert not is_archive(Path('ficheiro.txt'))
+
+
+def test_iterate_archive_reads_files(tmp_path):
+    zip_path = tmp_path / 'dados.zip'
+    with zipfile.ZipFile(zip_path, 'w') as z:
+        z.writestr('a.jpg', 'abc')
+        z.writestr('b.txt', 'xyz')
+
+    items = list(iterate_archive(zip_path, extensions=['jpg']))
+    assert len(items) == 1
+    nome, bio = items[0]
+    assert nome == 'a.jpg'
+    assert bio.read() == b'abc'

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import pytest
+
+from src.core.scanner import scan
+
+
+def test_scan_recursive_filters(tmp_path):
+    (tmp_path / 'a.jpg').write_text('jpg')
+    (tmp_path / 'a.txt').write_text('txt')
+    sub = tmp_path / 'sub'
+    sub.mkdir()
+    (sub / 'b.jpg').write_text('jpg')
+
+    found = list(scan(tmp_path, extensions=['jpg'], recursive=True))
+    rel = {p.relative_to(tmp_path) for p in found}
+    assert rel == {Path('a.jpg'), Path('sub/b.jpg')}
+
+
+def test_scan_missing_root():
+    missing = Path('nao_existe')
+    with pytest.raises(FileNotFoundError):
+        list(scan(missing, extensions=['jpg']))
+
+    # Com treat_missing_as_warning=True não deve lançar erro
+    assert list(scan(missing, extensions=['jpg'], treat_missing_as_warning=True)) == []


### PR DESCRIPTION
## Resumo
- Acrescentar testes para scanner, extractor e copier
- Documentar requisitos e execução na README

## Testes
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0efe416708325ba09cc357f02b834