### PR TITLE
Verificar duplicados ao copiar ficheiros

### DIFF
--- a/tests/test_copier.py
+++ b/tests/test_copier.py
@@ -27,3 +27,52 @@ def test_copy_selected_copies_only_requested(tmp_path):
     assert not (dst / 'txt').exists()
     assert stats['files_copied'] == 1
     assert progress[-1] == 1
+
+
+def test_copy_skips_if_identical(tmp_path):
+    src = tmp_path / 'src'
+    dst = tmp_path / 'dst'
+    src.mkdir()
+    (src / 'foto.jpg').write_text('img')
+    (dst / 'jpg').mkdir(parents=True)
+    (dst / 'jpg' / 'foto.jpg').write_text('img')
+
+    stats = {}
+    copy_selected(
+        src=src,
+        dst=dst,
+        extensions={'jpg'},
+        recursive=True,
+        preserve_structure=True,
+        stats=stats,
+    )
+
+    folder = dst / 'jpg'
+    assert list(folder.iterdir()) == [folder / 'foto.jpg']
+    assert stats['files_copied'] == 0
+
+
+def test_copy_adds_if_different(tmp_path):
+    src = tmp_path / 'src'
+    dst = tmp_path / 'dst'
+    src.mkdir()
+    (src / 'foto.jpg').write_text('new')
+    (dst / 'jpg').mkdir(parents=True)
+    (dst / 'jpg' / 'foto.jpg').write_text('old')
+
+    stats = {}
+    copy_selected(
+        src=src,
+        dst=dst,
+        extensions={'jpg'},
+        recursive=True,
+        preserve_structure=True,
+        stats=stats,
+    )
+
+    folder = dst / 'jpg'
+    files = sorted(p.name for p in folder.iterdir())
+    assert files == ['foto.jpg', 'foto_1.jpg']
+    assert (folder / 'foto.jpg').read_text() == 'old'
+    assert (folder / 'foto_1.jpg').read_text() == 'new'
+    assert stats['files_copied'] == 1


### PR DESCRIPTION
## Sumário
- evita sobrescrever ficheiros quando o mesmo conteúdo já existe
- cria nomes únicos para ficheiros semelhantes em vez de substituir

## Testes
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b10c2f31f483258ec7e068a0a8fdfd