### PR TITLE
Evitar duplicação de estatística VSS

### DIFF
--- a/src/core/copier.py
+++ b/src/core/copier.py
@@ -94,11 +94,13 @@ def copy_selected(
         mb_copied=0.0,
         ext_counts={},
         ext_sizes={},
-
-        vss={"usado": False, "motivo": "não solicitado"},
-
-        vss={"requested": use_vss, "success": False, "reason": None},
-
+        vss={
+            "usado": False,
+            "motivo": "não solicitado",
+            "requested": use_vss,
+            "success": False,
+            "reason": None,
+        },
     )
 
     if stop_flag is None:


### PR DESCRIPTION
## Resumo
- Combinar as definições de `vss` na inicialização de `stats` para manter todas as chaves num único dicionário.

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b251ac83fc832599d792dc279c603e